### PR TITLE
Match codeblock light vs dark mode when possible

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -866,7 +866,7 @@ pre, .markdown-rendered pre {
   --color-purple: #BD93F9 !important;
 }
 
-.gruvbox-dark-code-colors {
+.theme-dark.gruvbox-code-colors {
   --code-background: #282828 !important;
   --code-normal: #ebdbb2 !important;
   --code-punctuation: var(--code-normal) !important;
@@ -881,7 +881,7 @@ pre, .markdown-rendered pre {
   --color-purple: #BD93F9 !important;
 }
 
-.gruvbox-light-code-colors {
+.theme-light.gruvbox-code-colors {
   --code-background: #fbf1c7 !important;
   --code-normal: #3c3836 !important;
   --code-punctuation: var(--code-normal) !important;
@@ -911,7 +911,7 @@ pre, .markdown-rendered pre {
   --color-purple: #9c7fe5 !important;
 }
 
-.one-dark-code-colors {
+.theme-dark.one-code-colors {
   --code-background: #272b34 !important;
   --code-normal: #dcddde !important;
   --code-punctuation: var(--code-normal) !important;
@@ -926,7 +926,7 @@ pre, .markdown-rendered pre {
   --color-purple: #846ef1 !important;
 }
 
-.one-light-code-colors {
+.theme-light.one-code-colors {
   --code-background: #fafafa !important;
   --code-normal: #383a42 !important;
   --code-punctuation: var(--code-normal) !important;
@@ -954,7 +954,7 @@ pre, .markdown-rendered pre {
   --color-purple: rgb(140, 110, 240) !important;
 }
 
-.solarized-dark-code-colors {
+.theme-dark.solarized-code-colors {
   --code-background: #002b36 !important;
   --code-normal: #93a1a1 !important;
   --code-punctuation: var(--code-normal) !important;
@@ -969,7 +969,7 @@ pre, .markdown-rendered pre {
   --color-purple: #6c71c4 !important;
 }
 
-.solarized-light-code-colors {
+.theme-light.solarized-code-colors {
   --code-background: #eee8d5 !important;
   --code-normal: #839496 !important;
   --code-punctuation: var(--code-normal) !important;
@@ -1139,32 +1139,23 @@ settings:
       default: polka-code-colors
       options:
         -
-          label: Dracula
+          label: Dracula (dark)
           value: dracula-code-colors
         -
-          label: Gruvbox Dark
-          value: gruvbox-dark-code-colors
+          label: Gruvbox (light & dark)
+          value: gruvbox-code-colors
         -
-          label: Gruvbox Light
-          value: gruvbox-light-code-colors
-        -
-          label: Nord
+          label: Nord (dark)
           value: nord-code-colors
         -
-          label: One Dark
-          value: one-dark-code-colors
+          label: One (light & dark)
+          value: one-code-colors
         -
-          label: One Light
-          value: one-light-code-colors
-        -
-          label: Polka
+          label: Polka (dark)
           value: polka-code-colors
         -
-          label: Solarized Dark
-          value: solarized-dark-code-colors
-        -
-          label: Solarized Light
-          value: solarized-light-code-colors
+          label: Solarized (light & dark)
+          value: solarized-code-colors
     -
       id: ss-border-radius
       title: Roundness


### PR DESCRIPTION
This changes Polka's Style Settings for codeblock theming to respect and match Obsidian's current light vs. dark color scheme. Codeblock theme which have both a light and dark mode will switch, while fixed themes (e.g. Dracula) will remain the same in both light and dark modes.

Style Settings with this PR now shows:

<img width="794" alt="Screenshot 2024-01-27 at 11 04 55 AM" src="https://github.com/callumhackett/obsidian_polka_theme/assets/44155/6f24e0ec-de46-40ec-99da-c059b2b7f53f">


I went with the simplest approach in this PR, to just match codeblock styling to the current color scheme when possible. If anyone *really* wanted to have a fixed/contrasting codeblock styling, it would also be possible to offer both fixed and adaptive selections in Style Settings. However, that would make the list pretty long. E.g.:

- Dracula (dark)
- One (adaptive)
- One (light)
- One (dark)
- [... and so on]

Fixes #11
